### PR TITLE
Fix error when generating ngrams for too short text

### DIFF
--- a/src/ngram.rs
+++ b/src/ngram.rs
@@ -10,11 +10,15 @@ impl<'a> NGram<'a> {
   fn calculate(&self) -> Vec<Vec<&'a str>> {
     let mut tokenized_sequence = tokenize(self.text);
     tokenized_sequence.shrink_to_fit();
-    
-    let count = tokenized_sequence.len() - self.n + 1;
-    
+
     let mut ngram_result = Vec::new();
-    
+
+    if tokenized_sequence.len() < self.n {
+      return ngram_result
+    }
+
+    let count = tokenized_sequence.len() - self.n + 1;
+
     //left-padding
     if !self.pad.is_empty() {
       for i in 1..self.n {

--- a/src/phonetics.rs
+++ b/src/phonetics.rs
@@ -64,7 +64,7 @@ fn strip_similar_chars(chars: Vec<char>) -> Vec<char> {
 fn fix_length(mut chars: Vec<char>) -> Vec<char> {
   match chars.len() {
     4 => chars,
-    0...3 => add_more_zeros(chars),
+    0..=3 => add_more_zeros(chars),
     _ => { chars.truncate(4); chars} //truncate doesn't return self?
   }
 }

--- a/tests/ngram_tests.rs
+++ b/tests/ngram_tests.rs
@@ -13,3 +13,8 @@ fn test_ngram_with_pad() {
   assert_eq!(get_ngram_with_padding("my fleas", 2, "boo"), vec![
     vec!["boo", "my"], vec!["my", "fleas"], vec!["fleas", "boo"]]);
 }
+
+#[test]
+fn test_ngram_too_short() {
+  assert_eq!(get_ngram("singleword", 2).len(), 0);
+}


### PR DESCRIPTION
Right now the get_ngram function panics when the text is too short. I've fixed this and added a test also fixed the deprecated `...`.